### PR TITLE
🐛 fix: heroslider 스와이퍼 디자인 수정 및 slide 방향 수정

### DIFF
--- a/next-netflix-21th/src/app/page.tsx
+++ b/next-netflix-21th/src/app/page.tsx
@@ -2,9 +2,12 @@
 
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import Logo from "@/public/icons/header/logo.svg";
-import Lottie from "react-lottie-player";
 import LandingLottie from "@/public/lotties/LandingLottie.json";
+
+// react-lottie-player를 동적으로 불러오기 (SSR 비활성화)
+const Lottie = dynamic(() => import("react-lottie-player"), { ssr: false });
 
 const Landing = () => {
   const router = useRouter();

--- a/next-netflix-21th/src/components/home/HeroSlider.tsx
+++ b/next-netflix-21th/src/components/home/HeroSlider.tsx
@@ -1,72 +1,84 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { IMAGE_BASE_URL } from "@/constants/tmdb";
 import { getTrendingAllDay } from "@/apis/tmdb";
 import { TrendingItem } from "@/types/tmdb";
 import Image from "next/image";
 import Top10Icon from "@/public/icons/home/Top10Icon.svg";
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Autoplay } from "swiper/modules"; // Import Autoplay module
+import { Swiper as SwiperClass } from "swiper/types";
 import "swiper/css";
 
-const HeroSlider= () =>{
+const HeroSlider = () => {
   const [trendingData, setTrendingData] = useState<TrendingItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const swiperRef = useRef<SwiperClass | null>(null);
 
   useEffect(() => {
     const fetchTrending = async () => {
       try {
-        setLoading(true);
         const response = await getTrendingAllDay();
-        setTrendingData(response.data.results);
+        setTrendingData(response.data.results.slice(0, 10));
       } catch (error) {
         console.error("트랜딩 데이터 가져오기 실패", error);
-        setError("Failed to load trending data.");
-      } finally {
-        setLoading(false);
       }
     };
     fetchTrending();
   }, []);
 
-  if (loading) return <div>Loading...</div>;
-  if (error) return <div>{error}</div>;
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (swiperRef.current) {
+        swiperRef.current.slideNext(); // 항상 오른쪽으로만 넘어감
+      }
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
 
   return (
-    <Swiper
-      spaceBetween={10}
-      slidesPerView={1}
-      autoplay={{
-        delay: 3000, // 3 seconds
-        disableOnInteraction: true, // Pause on user interaction
-      }}
-      modules={[Autoplay]}
-    >
-      {trendingData.slice(0, 10).map((item, index) => {
-        const imageUrl = `${IMAGE_BASE_URL}original${item.poster_path}`;
-        const title = "title" in item ? item.title : item.name;
+    <div className="relative w-full h-[415px]">
+      <Swiper
+        spaceBetween={10}
+        slidesPerView={1}
+        loop={trendingData.length > 2}
+        onSlideChange={swiper => setActiveIndex(swiper.realIndex)}
+        onBeforeInit={swiper => {
+          swiperRef.current = swiper;
+        }}
+        className="w-full h-full"
+      >
+        {trendingData.map((item, index) => {
+          const imageUrl = `${IMAGE_BASE_URL}original${item.poster_path}`;
+          const title = "title" in item ? item.title : item.name;
 
-        return (
-          <SwiperSlide key={item.id} role="listitem">
-            <div className="relative w-full h-[440px]">
-              <Image
-                src={imageUrl}
-                alt={title}
-                fill
-                priority={index < 3}
-                quality={75}
-              />
-            </div>
-            <div className="flex items-center gap-2 mt-2">
-              <Top10Icon className="w-16 h-16 " />
-              <span>#{index + 1} in Korea Today</span>
-            </div>
-          </SwiperSlide>
-        );
-      })}
-    </Swiper>
+          return (
+            <SwiperSlide key={item.id}>
+              <div className="relative w-full h-full overflow-hidden">
+                <Image
+                  src={imageUrl}
+                  alt={title}
+                  fill
+                  sizes="375px"
+                  priority={index < 3}
+                  quality={75}
+                  className="object-cover"
+                />
+                <div className="absolute bottom-0 left-0 w-full h-1/4 z-10 bg-gradient-to-t from-[#00000073] to-transparent" />
+              </div>
+            </SwiperSlide>
+          );
+        })}
+      </Swiper>
+
+      <div className="absolute bottom-[-2px] left-1/2 transform -translate-x-1/2 z-20 flex items-center justify-center gap-[5px]">
+        <Top10Icon className="w-[15px] h-[15px]" />
+        <span className="text-white text-[13.72px] font-bold h-5">
+          #{activeIndex + 1} in Korea Today
+        </span>
+      </div>
+    </div>
   );
-}
+};
+
 export default HeroSlider;

--- a/next-netflix-21th/src/components/home/HeroSlider.tsx
+++ b/next-netflix-21th/src/components/home/HeroSlider.tsx
@@ -61,10 +61,9 @@ const HeroSlider = () => {
                   fill
                   sizes="375px"
                   priority={index < 3}
-                  quality={75}
                   className="object-cover"
                 />
-                <div className="absolute bottom-0 left-0 w-full h-1/4 z-10 bg-gradient-to-t from-[#00000073] to-transparent" />
+                <div className="absolute bottom-0 left-0 w-full h-1/4 z-10 bg-gradient-to-t from-black to-transparent" />
               </div>
             </SwiperSlide>
           );


### PR DESCRIPTION
### 🔥 작업 내용
- HeroSlider 하단에 그라디언트 배경 추가
→ 이미지 하단에 linear-gradient 적용

- Top10 아이콘 및 텍스트 위치 수정
→ 슬라이드 내부에서 함께 이동하던 구조를 제거하고 absolute로 고정하여 인덱스만 변경되도록 수정

- 슬라이드 루프 이동 방향 개선
→ 10 → 1 슬라이드 전환 시 왼쪽으로 돌아가는 문제 해결
→ 항상 오른쪽으로 자연스럽게 이동하도록 수동 slideNext() 방식으로 전환

- Image 컴포넌트의 fill 속성 사용 시 콘솔 경고 발생
→ sizes="375px" 추가하여 경고 해결 

- react-lottie-player에서 발생하는 SSR 오류 해결을 위해 dynamic import로 클라이언트 전용 로딩 처리 (ssr: false)

### 📸 피그마 스크린샷 or 기능 GIF

https://github.com/user-attachments/assets/fb8208a6-65b7-4184-9c37-7b7eb0ca5fc3